### PR TITLE
Fixed PopulateActions breaking inspect links

### DIFF
--- a/scripts/community/inventory.js
+++ b/scripts/community/inventory.js
@@ -203,7 +203,7 @@
 		}
 	};
 	
-	window.PopulateActions = function( elActions, rgActions, item, owner )
+	window.PopulateActions = function( prefix, elActions, rgActions, item, owner )
 	{
 		var foundState = FoundState.None;
 		
@@ -412,7 +412,7 @@
 			// Don't break website functionality if something fails above
 		}
 		
-		originalPopulateActions( elActions, rgActions, item, owner );
+		originalPopulateActions( prefix, elActions, rgActions, item, owner );
 		
 		// We want our links to be open in new tab
 		if( foundState === FoundState.Added )


### PR DESCRIPTION
Also fixed the fact that it literally didn't even work.

At some point like a year ago Valve changed this function to have another parameter at the start. It was never updated in the extension, causing the function to catch an error early on and never actually do anything.