### PR TITLE
🐛 Fix initial options window height extended off screen

### DIFF
--- a/options/options.css
+++ b/options/options.css
@@ -6,13 +6,16 @@
 
 html {
 	font-size: 16px;
+	overflow: hidden;
 }
 
 body {
-	margin: 2rem;
+	margin: 0;
+	padding: 2rem;
 	font: 1rem/1.5 "Helvetica Neue", Arial, sans-serif;
 	color: #5a5a5a;
 	min-width: 34rem;
+	overflow: auto;
 }
 
 a {

--- a/options/options.js
+++ b/options/options.js
@@ -42,4 +42,10 @@
 			element.checked = items[ item ];
 		}
 	} );
+
+	chrome.windows.getCurrent( function( chromeWindow )
+	{
+		var viewportHeight = chromeWindow.height;
+		document.getElementsByTagName( 'body' )[ 0 ].style = 'max-height: ' + viewportHeight * 0.8 + 'px;';
+	} );
 }() );


### PR DESCRIPTION
Calls the chrome api to determine the window height and set the max height at 80% #18.

Only issue present is that you cannot (as far as I have been able to find) detect resize events, so this is limited to the initial height of the window when the options are first opened.

Knowing the nature of the options panel, it's unlikely the browser would be resized during this event anyway.