### PR TITLE
chore: bump deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.idea/
 npm-debug.log
 package-lock.json
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
 		"fix": "eslint . --fix && stylelint \"**/*.css\" --fix"
 	},
 	"devDependencies": {
-		"@types/chrome": "^0.0.248",
-		"@types/firefox-webext-browser": "^111.0.1",
+		"@types/chrome": "^0.0.251",
+		"@types/firefox-webext-browser": "^111.0.4",
 		"archiver": "^6.0.1",
-		"eslint": "^8.47.0",
-		"eslint-config-standard": "^17.0.0",
-		"stylelint": "^15.10.2",
+		"eslint": "^8.53.0",
+		"eslint-config-standard": "^17.1.0",
+		"stylelint": "^15.11.0",
 		"stylelint-config-standard": "^34.0.0",
-		"web-ext": "^7.6.2"
+		"web-ext": "^7.8.0"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This PR bumps the following deps:
```
 @types/chrome                  ^0.0.248  →  ^0.0.251
 @types/firefox-webext-browser  ^111.0.1  →  ^111.0.4
 eslint                          ^8.47.0  →   ^8.53.0
 eslint-config-standard          ^17.0.0  →   ^17.1.0
 stylelint                      ^15.10.2  →  ^15.11.0
 web-ext                          ^7.6.2  →    ^7.8.0
```