### PR TITLE
Attempt to get a sale item (sticker) after successful queue auto-discovery

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -203,6 +203,74 @@
 	"explore_saleitem_trying_to_claim": {
 		"message": "Trying to claim a sale item if there is one…"
 	},
+	"explore_saleitem_cant_claim": {
+		"message": "No sale item to claim at this moment."
+	},
+	"explore_saleitem_can_claim_retrying": {
+		"message": "Failed to find out if a sale item can be claimed… Attempt $current$ of $total$",
+		"placeholders": {
+			"current": {
+				"content": "$1",
+				"example": "1"
+			},
+			"total": {
+				"content": "$2",
+				"example": "5"
+			}
+		}
+	},
+	"explore_saleitem_can_claim_failed": {
+		"message": "Failed to find out if a sale item can be claimed after $retries$ retries. Error: $error$",
+		"placeholders": {
+			"retries": {
+				"content": "$1",
+				"example": "5"
+			},
+			"error": {
+				"content": "$2",
+				"example": "HTTP 403"
+			}
+		}
+	},
+	"explore_saleitem_next_item_time": {
+		"message": "Next item available: $datetime$",
+		"placeholders": {
+			"datetime": {
+				"content": "$1",
+				"example": "01.07.2024, 20:00:00",
+				"description": "Date and time format depends on locale set in browser"
+			}
+		}
+	},
+	"explore_saleitem_claim_retrying": {
+		"message": "Failed to get a sale item, retrying… Attempt $current$ of $total$",
+		"placeholders": {
+			"current": {
+				"content": "$1",
+				"example": "1"
+			},
+			"total": {
+				"content": "$2",
+				"example": "5"
+			}
+		}
+	},
+	"explore_saleitem_claim_failed": {
+		"message": "Failed to get a sale item after $retries$ retries. Error: $error$",
+		"placeholders": {
+			"retries": {
+				"content": "$1",
+				"example": "5"
+			},
+			"error": {
+				"content": "$2",
+				"example": "HTTP 403"
+			}
+		}
+	},
+	"explore_saleitem_empty": {
+		"message": "No item ID returned while trying to get a sale item, perhaps it was already claimed."
+	},
 	"explore_saleitem_success": {
 		"message": "New sale item claimed: $item$.",
 		"placeholders": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -217,20 +217,7 @@
 		}
 	},
 	"explore_saleitem_claim_failed": {
-		"message": "Failed to get a sale item after $retries$ retries. Error: $error$",
-		"placeholders": {
-			"retries": {
-				"content": "$1",
-				"example": "5"
-			},
-			"error": {
-				"content": "$2",
-				"example": "HTTP 403"
-			}
-		}
-	},
-	"explore_saleitem_empty": {
-		"message": "No item ID returned while trying to get a sale item, perhaps it was already claimed."
+		"message": "Failed to claim a sale item."
 	},
 	"explore_saleitem_success": {
 		"message": "New sale item claimed: $item$.",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -200,6 +200,18 @@
 	"explore_finished": {
 		"message": "Queue has been explored."
 	},
+	"explore_saleitem_trying_to_claim": {
+		"message": "Trying to claim a sale item if there is one…"
+	},
+	"explore_saleitem_success": {
+		"message": "New sale item claimed: $item$.",
+		"placeholders": {
+			"item": {
+				"content": "$1",
+				"example": "Unicorn Sticker"
+			}
+		}
+	},
 
 	"badges_idle_apps": {
 		"message": "Apps to idle: $amount$",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -206,32 +206,6 @@
 	"explore_saleitem_cant_claim": {
 		"message": "No sale item to claim at this moment."
 	},
-	"explore_saleitem_can_claim_retrying": {
-		"message": "Failed to find out if a sale item can be claimed… Attempt $current$ of $total$",
-		"placeholders": {
-			"current": {
-				"content": "$1",
-				"example": "1"
-			},
-			"total": {
-				"content": "$2",
-				"example": "5"
-			}
-		}
-	},
-	"explore_saleitem_can_claim_failed": {
-		"message": "Failed to find out if a sale item can be claimed after $retries$ retries. Error: $error$",
-		"placeholders": {
-			"retries": {
-				"content": "$1",
-				"example": "5"
-			},
-			"error": {
-				"content": "$2",
-				"example": "HTTP 403"
-			}
-		}
-	},
 	"explore_saleitem_next_item_time": {
 		"message": "Next item available: $datetime$",
 		"placeholders": {
@@ -239,19 +213,6 @@
 				"content": "$1",
 				"example": "01.07.2024, 20:00:00",
 				"description": "Date and time format depends on locale set in browser"
-			}
-		}
-	},
-	"explore_saleitem_claim_retrying": {
-		"message": "Failed to get a sale item, retrying… Attempt $current$ of $total$",
-		"placeholders": {
-			"current": {
-				"content": "$1",
-				"example": "1"
-			},
-			"total": {
-				"content": "$2",
-				"example": "5"
 			}
 		}
 	},

--- a/scripts/store/explore.js
+++ b/scripts/store/explore.js
@@ -211,7 +211,6 @@ function ClaimSaleItem()
 
 						if( fails < maxRetries )
 						{
-							itemStatus.textContent = _t( 'explore_saleitem_claim_retrying', [ fails, maxRetries ] );
 							setTimeout( () =>
 							{
 								claimItem( fails );
@@ -262,7 +261,6 @@ function ClaimSaleItem()
 
 						if( fails < maxRetries )
 						{
-							itemStatus.textContent = _t( 'explore_saleitem_can_claim_retrying', [ fails, maxRetries ] );
 							setTimeout( () =>
 							{
 								canClaimItem( fails );
@@ -270,7 +268,7 @@ function ClaimSaleItem()
 						}
 						else
 						{
-							itemStatus.textContent = _t( 'explore_saleitem_can_claim_failed', [ maxRetries, error.message ] );
+							itemStatus.textContent = _t( 'explore_saleitem_claim_failed', [ maxRetries, error.message ] );
 						}
 					} );
 			};

--- a/scripts/store/explore.js
+++ b/scripts/store/explore.js
@@ -201,7 +201,7 @@ function ClaimSaleItem()
 						}
 						else
 						{
-							itemStatus.textContent = _t( 'explore_saleitem_empty' );
+							itemStatus.textContent = _t( 'explore_saleitem_claim_failed' );
 						}
 					} )
 					.catch( ( error ) =>
@@ -218,7 +218,7 @@ function ClaimSaleItem()
 						}
 						else
 						{
-							itemStatus.textContent = _t( 'explore_saleitem_claim_failed', [ maxRetries, error.message ] );
+							itemStatus.textContent = _t( 'explore_saleitem_claim_failed' );
 						}
 					} );
 			};

--- a/scripts/store/explore.js
+++ b/scripts/store/explore.js
@@ -10,24 +10,34 @@ if( emptyQueue )
 
 const buttonContainer = document.createElement( 'div' );
 buttonContainer.className = 'discovery_queue_customize_ctn';
+buttonContainer.style.display = 'flex';
+buttonContainer.style.alignItems = 'center';
 
 const button = document.createElement( 'div' );
 button.className = 'btnv6_blue_hoverfade btn_medium';
-let span = document.createElement( 'span' );
+const span = document.createElement( 'span' );
 span.appendChild( document.createTextNode( _t( 'explore_auto_discover' ) ) );
 button.appendChild( span );
 buttonContainer.appendChild( button );
 
-span = document.createElement( 'span' );
-span.style.lineHeight = '32px';
-span.appendChild( document.createTextNode( _t( 'explore_auto_discover_description' ) ) );
-buttonContainer.appendChild( span );
+const textElements = document.createElement( 'div' );
+
+const exploreStatus = document.createElement( 'div' );
+exploreStatus.style.lineHeight = '32px';
+exploreStatus.appendChild( document.createTextNode( _t( 'explore_auto_discover_description' ) ) );
+textElements.appendChild( exploreStatus );
+
+const itemStatus = document.createElement( 'div' );
+itemStatus.style.lineHeight = '32px';
+textElements.appendChild( itemStatus );
+
+buttonContainer.appendChild( textElements );
 
 const image = document.createElement( 'img' );
 image.src = GetLocalResource( 'icons/white.svg' );
 image.width = 32;
 image.height = 32;
-image.style.float = 'right';
+image.style.marginLeft = 'auto';
 buttonContainer.appendChild( image );
 
 const container = document.querySelector( '.discovery_queue_customize_ctn' );
@@ -45,11 +55,11 @@ function GenerateQueue()
 
 	if( !session )
 	{
-		span.textContent = 'Failed to find g_sessionID'; // This shouldn't happen, so don't translate
+		exploreStatus.textContent = 'Failed to find g_sessionID'; // This shouldn't happen, so don't translate
 		return;
 	}
 
-	span.textContent = _t( 'explore_generating' );
+	exploreStatus.textContent = _t( 'explore_generating' );
 
 	let formData = new FormData();
 	formData.append( 'sessionid', session.groups.sessionid );
@@ -79,13 +89,13 @@ function GenerateQueue()
 
 				if( ++done === data.queue.length )
 				{
-					span.textContent = _t( 'explore_finished' );
+					exploreStatus.textContent = _t( 'explore_finished' );
 
 					ClaimSaleItem();
 				}
 				else
 				{
-					span.textContent = _t( 'explore_exploring', [ done, data.queue.length ] );
+					exploreStatus.textContent = _t( 'explore_exploring', [ done, data.queue.length ] );
 
 					requestNextInQueue( done );
 				}
@@ -97,12 +107,12 @@ function GenerateQueue()
 
 				if( ++fails >= 10 )
 				{
-					span.textContent = _t( 'explore_failed_to_clear_too_many', [ done ] );
+					exploreStatus.textContent = _t( 'explore_failed_to_clear_too_many', [ done ] );
 
 					return;
 				}
 
-				span.textContent = _t( 'explore_failed_to_clear', [ done ] );
+				exploreStatus.textContent = _t( 'explore_failed_to_clear', [ done ] );
 
 				setTimeout( () =>
 				{
@@ -136,7 +146,7 @@ function GenerateQueue()
 
 			setTimeout( GenerateQueue, RandomInt( 5000, 10000 ) );
 
-			span.textContent = _t( 'explore_failed_to_generate' );
+			exploreStatus.textContent = _t( 'explore_failed_to_generate' );
 		} );
 }
 
@@ -145,55 +155,127 @@ function ClaimSaleItem()
 	const applicationConfigElement = document.getElementById( 'application_config' );
 	if( applicationConfigElement )
 	{
-		const userConfigJSON = applicationConfigElement.dataset.store_user_config;
-		const webapiToken =
-			userConfigJSON && JSON.parse( userConfigJSON ).webapi_token;
+		const storeUserConfigJSON = applicationConfigElement.dataset.store_user_config;
+		const webapiToken = storeUserConfigJSON && JSON.parse( storeUserConfigJSON ).webapi_token;
 
 		if( webapiToken )
 		{
-			let result = span.textContent; // storing explore result to show again after trying to get a sale item
-			span.textContent = _t( 'explore_saleitem_trying_to_claim' );
+			itemStatus.textContent = _t( 'explore_saleitem_trying_to_claim' );
 
-			fetch(
-				`https://api.steampowered.com/ISaleItemRewardsService/ClaimItem/v1?access_token=${webapiToken}`,
-				{
-					method: 'POST',
-				},
-			)
-				.then( ( response ) =>
-				{
-					if( response.ok )
+			const params = new URLSearchParams();
+			params.set( 'access_token', webapiToken );
+
+			const configJSON = applicationConfigElement.dataset.config;
+			const language = configJSON && JSON.parse( configJSON ).LANGUAGE;
+			if( language )
+			{
+				params.set( 'language', language );
+			}
+
+			const claimItem = ( fails = 0, maxRetries = 5 ) =>
+			{
+				fetch(
+					`https://api.steampowered.com/ISaleItemRewardsService/ClaimItem/v1?${params.toString()}`,
 					{
-						return response.json();
-					}
-					else
+						method: 'POST',
+					},
+				)
+					.then( ( response ) =>
 					{
-						throw new Error( `HTTP ${response.status}` );
-					}
-				} )
-				.then( ( data ) =>
-				{
-					const response = data.response;
-					if( response && response.communityitemid )
+						if( response.ok )
+						{
+							return response.json();
+						}
+						else
+						{
+							throw new Error( `HTTP ${response.status}` );
+						}
+					} )
+					.then( ( data ) =>
 					{
-						const itemTitle = response.reward_item?.community_item_data?.item_title;
-						result += ' ' + _t(	'explore_saleitem_success',	[ itemTitle || `ID #${response.communityitemid}` ] );
-					}
-					else
+						const response = data.response;
+						if( response && response.communityitemid )
+						{
+							const itemTitle = response.reward_item?.community_item_data?.item_title;
+							itemStatus.textContent = _t( 'explore_saleitem_success', [ itemTitle || `ID #${response.communityitemid}` ] );
+						}
+						else
+						{
+							itemStatus.textContent = _t( 'explore_saleitem_empty' );
+						}
+					} )
+					.catch( ( error ) =>
 					{
-						throw new Error(
-							'No item ID returned while trying to get a sale item, perhaps it was already claimed.',
-						);
-					}
-				} )
-				.catch( ( error ) =>
-				{
-					WriteLog( 'Failed to get a sale item', error );
-				} )
-				.finally( () =>
-				{
-					span.textContent = result;
-				} );
+						WriteLog( 'Failed to get a sale item', error );
+						fails++;
+
+						if( fails < maxRetries )
+						{
+							itemStatus.textContent = _t( 'explore_saleitem_claim_retrying', [ fails, maxRetries ] );
+							setTimeout( () =>
+							{
+								claimItem( fails );
+							}, RandomInt( 5000, 10000 ) );
+						}
+						else
+						{
+							itemStatus.textContent = _t( 'explore_saleitem_claim_failed', [ maxRetries, error.message ] );
+						}
+					} );
+			};
+
+			const canClaimItem = ( fails = 0, maxRetries = 5 ) =>
+			{
+				fetch( `https://api.steampowered.com/ISaleItemRewardsService/CanClaimItem/v1?${params.toString()}` )
+					.then( ( response ) =>
+					{
+						if( response.ok )
+						{
+							return response.json();
+						}
+						else
+						{
+							throw new Error( `HTTP ${response.status}` );
+						}
+					} )
+					.then( ( data ) =>
+					{
+						const response = data.response;
+						if( response && response.can_claim === true )
+						{
+							claimItem();
+						}
+						else
+						{
+							itemStatus.textContent = _t( 'explore_saleitem_cant_claim' );
+							if( response.next_claim_time )
+							{
+								const nextClaimTime = new Date( response.next_claim_time * 1000 );
+								itemStatus.textContent += ' ' + _t( 'explore_saleitem_next_item_time', [ nextClaimTime.toLocaleString() ] );
+							}
+						}
+					} )
+					.catch( ( error ) =>
+					{
+						WriteLog( 'Failed to find out if a sale item can be claimed', error );
+						fails++;
+
+						if( fails < maxRetries )
+						{
+							itemStatus.textContent = _t( 'explore_saleitem_can_claim_retrying', [ fails, maxRetries ] );
+							setTimeout( () =>
+							{
+								canClaimItem( fails );
+							}, RandomInt( 5000, 10000 ) );
+						}
+						else
+						{
+							itemStatus.textContent = _t( 'explore_saleitem_can_claim_failed', [ maxRetries, error.message ] );
+						}
+					} );
+			};
+
+			canClaimItem();
 		}
 	}
 }


### PR DESCRIPTION
This should work. Item name will be displayed if it was gotten successfully. If for some reason there is no title for that item we'll show item ID (I don't think this should ever happen).
Otherwise just show queue exploring result again with no mention of trying to get an item and log the reason of not getting it (HTTP error code or response with no item ID).

I'm also assuming that if there is `data-store_user_config` attribute of `#application_config` element, it contains valid JSON.