### PR TITLE
Make achievement enhancements work on comparison pages

### DIFF
--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -528,7 +528,7 @@ function InitAchievements( items, isPersonal )
 			const text = document.createElement( 'div' );
 			text.textContent = unlock;
 			unlockRow.append( text );
-			
+
 			if( !isLeftPlayer )
 			{
 				text.className = 'steamdb_achievement_status_row_compare';
@@ -574,7 +574,7 @@ function InitAchievements( items, isPersonal )
 				progressWidth = Math.ceil( current / total * 100 ) + '%';
 			}
 
-			const info = document.createElement('div');
+			const info = document.createElement( 'div' );
 			info.textContent = progressText;
 			progress.append( info );
 

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -557,7 +557,7 @@ function InitAchievements( items, isPersonal )
 		const CreateProgressRow = ( progressText, progressWidth, isLeftPlayer = true ) =>
 		{
 			const progressRow = document.createElement( 'div' );
-			progressRow.className = 'steamdb_achievement_status_row';
+			progressRow.className = 'steamdb_achievement_status_row steamdb_achievement_status_locked';
 
 			const progress = document.createElement( 'div' );
 			progress.className = 'steamdb_achievement_progress';

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -431,11 +431,11 @@ function InitAchievements( items, isPersonal )
 
 			if( progress )
 			{
-				if ( isCompareView )
+				if( isCompareView )
 				{
 					progressText = progress
 						.querySelector( '.progressText' )
-						?.childNodes[0].textContent.trim();
+						?.childNodes[ 0 ].textContent.trim();
 					progressTextCompare = progress
 						.querySelector( '.progressText .compareVal' )
 						?.textContent.trim();
@@ -556,14 +556,15 @@ function InitAchievements( items, isPersonal )
 				avatar.src = isLeftPlayer ? leftAvatarUrl : rightAvatarUrl;
 				progressRow.append( avatar );
 
-				if ( !isLeftPlayer ) {
-					progress.classList.add('steamdb_achievement_progress_compare')
+				if( !isLeftPlayer )
+				{
+					progress.classList.add( 'steamdb_achievement_progress_compare' );
 					// removing parentheses from start and end of second player progress text
-					progressText = progressText.replace(/^\(/, '').replace(/\)$/, '');
-	
+					progressText = progressText.replace( /^\(/, '' ).replace( /\)$/, '' );
+
 					// trying to get progress based on text, as right player doesn't have a bar
-					const [ current, total ] = progressText.split('/').map(val => val.replace(/\,/g, '').trim());
-					progressWidth = Math.ceil(current / total * 100) + '%';
+					const [ current, total ] = progressText.split( '/' ).map( val => val.replace( /,/g, '' ).trim() );
+					progressWidth = Math.ceil( current / total * 100 ) + '%';
 				}
 			}
 
@@ -580,10 +581,10 @@ function InitAchievements( items, isPersonal )
 			progressBarInner.style.width = progressWidth;
 			progressBar.append( progressBarInner );
 
-			progressRow.append(progress);
+			progressRow.append( progress );
 
 			return progressRow;
-		}
+		};
 
 		const CreateAchievementRow = ( { id, achievement, player } ) =>
 		{
@@ -689,7 +690,7 @@ function InitAchievements( items, isPersonal )
 				);
 				status.append( unlockRow );
 			}
-			else if ( player.progressText )
+			else if( player.progressText )
 			{
 				const progressRow = CreateProgressRow( true, player.progressText, player.progressWidth );
 				status.append( progressRow );
@@ -704,7 +705,7 @@ function InitAchievements( items, isPersonal )
 				);
 				status.append( unlockRow );
 			}
-			else if ( player.progressTextCompare )
+			else if( player.progressTextCompare )
 			{
 				const progressRow = CreateProgressRow( false, player.progressTextCompare, null );
 				status.append( progressRow );
@@ -717,7 +718,7 @@ function InitAchievements( items, isPersonal )
 
 			element.append( status );
 
-			if ( isCompareView )
+			if( isCompareView )
 			{
 				const image = document.createElement( 'img' );
 				image.src = `${applicationConfig.MEDIA_CDN_COMMUNITY_URL}images/apps/${appid}/${player.unlockCompare ? achievement.icon : achievement.icon_gray}`;
@@ -1056,6 +1057,10 @@ function InitAchievements( items, isPersonal )
 			gameLogoElement.hidden = true;
 
 			document.querySelector( '#topSummaryAchievements .achieveBar' )?.classList.add( 'steamdb_achievement_progressbar' );
+			if( isCompareView )
+			{
+				document.querySelector( '#topSummaryAchievements :nth-child(2 of .achieveBar)' )?.classList.add( 'steamdb_achievement_progressbar' );
+			}
 
 			// As we are completely redrawing the achievement list, sorting added by
 			// Augmented Steam won't work it, hide their sorting to prevent user confusion

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -566,7 +566,7 @@ function InitAchievements( items, isPersonal )
 					progressWidth = Math.ceil(current / total * 100) + '%';
 				}
 			}
-			console.log(progressWidth);
+
 			const text = document.createElement( 'div' );
 			text.textContent = progressText;
 			progress.append( text );
@@ -716,6 +716,14 @@ function InitAchievements( items, isPersonal )
 			}
 
 			element.append( status );
+
+			if ( isCompareView )
+			{
+				const image = document.createElement( 'img' );
+				image.src = `${applicationConfig.MEDIA_CDN_COMMUNITY_URL}images/apps/${appid}/${player.unlockCompare ? achievement.icon : achievement.icon_gray}`;
+				image.className = 'steamdb_achievement_image';
+				element.append( image );
+			}
 
 			return element;
 		};

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -598,6 +598,19 @@ function InitAchievements( items, isPersonal )
 			return progressRow;
 		};
 
+		const CreateLockRow = ( isLeftPlayer ) =>
+		{
+			const lockRow = document.createElement( 'div' );
+			lockRow.className = 'steamdb_achievement_status_row steamdb_achievement_status_locked';
+
+			const avatar = document.createElement( 'img' );
+			avatar.className = 'steamdb_achievement_status_avatar';
+			avatar.src = isLeftPlayer ? leftAvatarUrl : rightAvatarUrl;
+			lockRow.append( avatar );
+
+			return lockRow;
+		};
+
 		const CreateAchievementRow = ( { id, achievement, player } ) =>
 		{
 			const element = document.createElement( 'div' );
@@ -711,6 +724,11 @@ function InitAchievements( items, isPersonal )
 				const progressRow = CreateProgressRow( player.progressText, player.progressWidth, true );
 				status.append( progressRow );
 			}
+			else if( isCompareView )
+			{
+				const locked = CreateLockRow( true );
+				status.append( locked );
+			}
 
 			if( player.unlockCompare )
 			{
@@ -725,6 +743,11 @@ function InitAchievements( items, isPersonal )
 			{
 				const progressRow = CreateProgressRow( player.progressTextCompare, null, false );
 				status.append( progressRow );
+			}
+			else if( isCompareView )
+			{
+				const locked = CreateLockRow( false );
+				status.append( locked );
 			}
 
 			if( achievement.global_unlock < 0.1 )
@@ -829,16 +852,29 @@ function InitAchievements( items, isPersonal )
 			const progress = document.createElement( 'div' );
 			progress.className = 'steamdb_achievement_progress';
 			if( !isLeftPlayer ) progress.classList.add( 'steamdb_achievement_progress_compare' );
-			progress.textContent = `${earned} / ${total} (${percentFormatter.format( percentage )})`;
+
+			const info = document.createElement( 'div' );
+			info.className = 'steamdb_achievement_progress_info';
+			info.textContent = `${earned} / ${total} (${percentFormatter.format( percentage )})`;
 
 			const progressBar = document.createElement( 'div' );
 			progressBar.className = 'steamdb_achievement_progressbar';
-			progress.append( progressBar );
 
 			const progressBarInner = document.createElement( 'div' );
 			progressBarInner.className = 'steamdb_achievement_progressbar_inner';
 			progressBarInner.style.width = Math.round( percentage * 100 ) + '%';
 			progressBar.append( progressBarInner );
+
+			info.append( progressBar );
+			progress.append( info );
+
+			if( isCompareView )
+			{
+				const avatar = document.createElement( 'img' );
+				avatar.className = 'steamdb_achievement_progress_avatar';
+				avatar.src = isLeftPlayer ? leftAvatarUrl : rightAvatarUrl;
+				progress.append( avatar );
+			}
 
 			return progress;
 		};

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -120,15 +120,23 @@ function InitAchievements( items, isPersonal )
 
 	extraTabs.append( CreateFoldButton( true ) );
 
-	if( window.innerWidth < 600 )
+	function AppendExtraTabs()
 	{
-		extraTabs.classList.add( 'steamdb_stats_extra_tabs_mobile' );
-		document.querySelector( '#subtabs' ).insertAdjacentElement( 'afterend', extraTabs );
+		if( window.innerWidth < 600 )
+		{
+			extraTabs.classList.add( 'steamdb_stats_extra_tabs_mobile' );
+			document
+				.querySelector( '#subtabs' )
+				.insertAdjacentElement( 'afterend', extraTabs );
+		}
+		else
+		{
+			extraTabs.classList.remove( 'steamdb_stats_extra_tabs_mobile' );
+			document.querySelector( '#tabs' ).append( extraTabs );
+		}
 	}
-	else
-	{
-		document.querySelector( '#tabs' ).append( extraTabs );
-	}
+	AppendExtraTabs();
+	window.addEventListener( 'resize', AppendExtraTabs );
 
 	if( isPersonal )
 	{

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -527,6 +527,8 @@ function InitAchievements( items, isPersonal )
 
 			const text = document.createElement( 'div' );
 			text.textContent = unlock;
+			unlockRow.append( text );
+			
 			if( !isLeftPlayer )
 			{
 				text.className = 'steamdb_achievement_status_row_compare';
@@ -540,7 +542,6 @@ function InitAchievements( items, isPersonal )
 				);
 				text.append( relativeUnlock );
 			}
-			unlockRow.append( text );
 
 			if( isCompareView )
 			{
@@ -560,6 +561,7 @@ function InitAchievements( items, isPersonal )
 
 			const progress = document.createElement( 'div' );
 			progress.className = 'steamdb_achievement_progress';
+			progressRow.append( progress );
 
 			if( !isLeftPlayer )
 			{
@@ -572,20 +574,18 @@ function InitAchievements( items, isPersonal )
 				progressWidth = Math.ceil( current / total * 100 ) + '%';
 			}
 
-			const text = document.createElement( 'div' );
-			text.textContent = progressText;
-			progress.append( text );
+			const info = document.createElement('div');
+			info.textContent = progressText;
+			progress.append( info );
 
 			const progressBar = document.createElement( 'div' );
 			progressBar.className = 'steamdb_achievement_progressbar';
-			progress.append( progressBar );
+			info.append( progressBar );
 
 			const progressBarInner = document.createElement( 'div' );
 			progressBarInner.className = 'steamdb_achievement_progressbar_inner';
 			progressBarInner.style.width = progressWidth;
 			progressBar.append( progressBarInner );
-
-			progressRow.append( progress );
 
 			if( isCompareView )
 			{

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -614,7 +614,11 @@ function InitAchievements( items, isPersonal )
 			name.textContent = achievement.localized_name;
 			nameContainer.append( name );
 
-			if( achievement.hidden && !player.unlock )
+			if(
+				achievement.hidden &&
+				( ( !player.unlock && !isCompareView ) ||
+				( !player.unlockCompare && isCompareView ) )
+			)
 			{
 				const hiddenAch = document.createElement( 'i' );
 				hiddenAch.textContent = _t( 'hidden_achievement' );

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -348,6 +348,7 @@ function InitAchievements( items, isPersonal )
 		{
 			const update = achievementUpdates[ updateId ];
 			update.earned = 0;
+			update.earnedCompare = 0;
 			update.achievementData = [];
 			update.earnedDetailsElement = null;
 
@@ -378,6 +379,11 @@ function InitAchievements( items, isPersonal )
 			if( ach.player.unlock )
 			{
 				update.earned++;
+			}
+
+			if( ach.player.unlockCompare )
+			{
+				update.earnedCompare++;
 			}
 		};
 
@@ -510,7 +516,7 @@ function InitAchievements( items, isPersonal )
 			maximumFractionDigits: 1,
 		} );
 
-		const CreateUnlockRow = ( isLeftPlayer, unlock, unlockTimestamp ) =>
+		const CreateUnlockRow = ( unlock, unlockTimestamp, isLeftPlayer ) =>
 		{
 			const unlockRow = document.createElement( 'div' );
 			unlockRow.className = 'steamdb_achievement_status_row';
@@ -541,7 +547,7 @@ function InitAchievements( items, isPersonal )
 			return unlockRow;
 		};
 
-		const CreateProgressRow = ( isLeftPlayer, progressText, progressWidth ) =>
+		const CreateProgressRow = ( progressText, progressWidth, isLeftPlayer = true ) =>
 		{
 			const progressRow = document.createElement( 'div' );
 			progressRow.className = 'steamdb_achievement_status_row';
@@ -684,30 +690,30 @@ function InitAchievements( items, isPersonal )
 			if( player.unlock )
 			{
 				const unlockRow = CreateUnlockRow(
-					true,
 					player.unlock,
 					player.unlockTimestamp,
+					true,
 				);
 				status.append( unlockRow );
 			}
 			else if( player.progressText )
 			{
-				const progressRow = CreateProgressRow( true, player.progressText, player.progressWidth );
+				const progressRow = CreateProgressRow( player.progressText, player.progressWidth, true );
 				status.append( progressRow );
 			}
 
 			if( player.unlockCompare )
 			{
 				const unlockRow = CreateUnlockRow(
-					false,
 					player.unlockCompare,
 					null,
+					false,
 				);
 				status.append( unlockRow );
 			}
 			else if( player.progressTextCompare )
 			{
-				const progressRow = CreateProgressRow( false, player.progressTextCompare, null );
+				const progressRow = CreateProgressRow( player.progressTextCompare, null, false );
 				status.append( progressRow );
 			}
 
@@ -807,6 +813,26 @@ function InitAchievements( items, isPersonal )
 			}
 		} );
 
+		const CreateProgressSummary = ( earned, total, isLeftPlayer = true ) =>
+		{
+			const percentage = earned / total;
+			const progress = document.createElement( 'div' );
+			progress.className = 'steamdb_achievement_progress';
+			if( !isLeftPlayer ) progress.classList.add( 'steamdb_achievement_progress_compare' );
+			progress.textContent = `${earned} / ${total} (${percentFormatter.format( percentage )})`;
+
+			const progressBar = document.createElement( 'div' );
+			progressBar.className = 'steamdb_achievement_progressbar';
+			progress.append( progressBar );
+
+			const progressBarInner = document.createElement( 'div' );
+			progressBarInner.className = 'steamdb_achievement_progressbar_inner';
+			progressBarInner.style.width = Math.round( percentage * 100 ) + '%';
+			progressBar.append( progressBarInner );
+
+			return progress;
+		};
+
 		for( let updateId = 0; updateId < achievementUpdates.length; updateId++ )
 		{
 			const update = achievementUpdates[ updateId ];
@@ -873,20 +899,13 @@ function InitAchievements( items, isPersonal )
 				summary.append( summaryText );
 
 				{
-					const percentage = update.earned / update.achievementData.length;
-					const progress = document.createElement( 'div' );
-					progress.className = 'steamdb_achievement_progress';
-					progress.textContent = `${update.earned} / ${update.achievementData.length} (${percentFormatter.format( percentage )})`;
+					const progress = CreateProgressSummary( update.earned, update.achievementData.length, true );
+					summaryText.append( progress );
+				}
 
-					const progressBar = document.createElement( 'div' );
-					progressBar.className = 'steamdb_achievement_progressbar';
-					progress.append( progressBar );
-
-					const progressBarInner = document.createElement( 'div' );
-					progressBarInner.className = 'steamdb_achievement_progressbar_inner';
-					progressBarInner.style.width = Math.round( percentage * 100 ) + '%';
-					progressBar.append( progressBarInner );
-
+				if( isCompareView )
+				{
+					const progress = CreateProgressSummary( update.earnedCompare, update.achievementData.length, false );
 					summaryText.append( progress );
 				}
 

--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -619,7 +619,7 @@ function InitAchievements( items, isPersonal )
 				nameContainer.append( globalUnlock );
 			}
 
-			if( player.unlock )
+			if( player.unlock || player.unlockCompare )
 			{
 				const unlock = document.createElement( 'div' );
 				unlock.className = 'steamdb_achievement_unlock';

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -248,11 +248,27 @@ html {
 }
 
 .steamdb_achievement_unlock {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
 	margin-left: auto;
-	text-align: right;
 	font-size: 12px;
 	font-weight: 400;
 	color: #8b929a;
+}
+
+.steamdb_achievement_unlock_row {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.steamdb_achievement_unlock_avatar {
+	height: 16px;
+}
+
+.steamdb_achievement_unlock_row_compare {
+	color: #ffcc6a;
 }
 
 .steamdb_achievement_unlock_global {

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -260,11 +260,12 @@ html {
 .steamdb_achievement_status_row {
 	display: flex;
 	align-items: center;
+	justify-content: end;
 	gap: 5px;
 }
 
 .steamdb_achievement_status_avatar {
-	height: 16px;
+	height: 24px;
 }
 
 .steamdb_achievement_status_row_compare {
@@ -290,7 +291,7 @@ html {
 }
 
 .steamdb_achievement_progress_compare {
-	color: #8f723b;
+	color: #ffcc6a;
 }
 
 .steamdb_achievements_title .steamdb_achievement_progress {
@@ -321,12 +322,9 @@ html {
 	width: 0%;
 }
 
-:nth-child(2 of .steamdb_achievement_progressbar) .achieveBarProgress {
-	background: #ffcc6a;
-}
-
+.steamdb_achievement_progressbar.steamdb_achievement_progress_compare .achieveBarProgress,
 .steamdb_achievement_progress_compare .steamdb_achievement_progressbar_inner {
-	background: #8f723b;
+	background: #ffcc6a;
 }
 
 .steamdb_achievement_groups_disclaimer {

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -22,6 +22,10 @@ html {
 	top: 22px;
 }
 
+#topSummaryAchievements .compareVal {
+	margin-top: 10px;
+}
+
 .steamdb_global_achievements_page {
 	padding: 0 !important;
 }
@@ -261,11 +265,15 @@ html {
 	display: flex;
 	align-items: center;
 	justify-content: end;
-	gap: 5px;
+	gap: 8px;
 }
 
 .steamdb_achievement_status_avatar {
 	height: 24px;
+}
+
+.steamdb_achievement_status_locked .steamdb_achievement_status_avatar {
+	opacity: .2;
 }
 
 .steamdb_achievement_status_row_compare {
@@ -282,6 +290,8 @@ html {
 }
 
 .steamdb_achievement_progress {
+	display: flex;
+	gap: 10px;
 	margin-left: auto;
 	font-size: 12px;
 	font-weight: 400;
@@ -294,8 +304,17 @@ html {
 	color: #ffcc6a;
 }
 
+.steamdb_achievements_name_container .steamdb_achievement_progress_compare {
+	margin-top: 10px;
+}
+
 .steamdb_achievements_title .steamdb_achievement_progress {
 	text-align: left;
+}
+
+.steamdb_achievement_progress_avatar {
+	height: 26px;
+	align-self: center;
 }
 
 .steamdb_achievement_progressbar {

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -247,7 +247,7 @@ html {
 	fill: #fff;
 }
 
-.steamdb_achievement_unlock {
+.steamdb_achievement_status {
 	display: flex;
 	flex-direction: column;
 	gap: 5px;
@@ -257,17 +257,17 @@ html {
 	color: #8b929a;
 }
 
-.steamdb_achievement_unlock_row {
+.steamdb_achievement_status_row {
 	display: flex;
 	align-items: center;
 	gap: 5px;
 }
 
-.steamdb_achievement_unlock_avatar {
+.steamdb_achievement_status_avatar {
 	height: 16px;
 }
 
-.steamdb_achievement_unlock_row_compare {
+.steamdb_achievement_status_row_compare {
 	color: #ffcc6a;
 }
 
@@ -287,6 +287,10 @@ html {
 	color: #b8bcbf;
 	text-align: right;
 	white-space: nowrap;
+}
+
+.steamdb_achievement_progress_compare {
+	color: #8f723b;
 }
 
 .steamdb_achievements_title .steamdb_achievement_progress {
@@ -315,6 +319,10 @@ html {
 	border-bottom-right-radius: 10px;
 	background: #1a9fff;
 	width: 0%;
+}
+
+.steamdb_achievement_progress_compare .steamdb_achievement_progressbar_inner {
+	background: #8f723b;
 }
 
 .steamdb_achievement_groups_disclaimer {

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -321,6 +321,10 @@ html {
 	width: 0%;
 }
 
+:nth-child(2 of .steamdb_achievement_progressbar) .achieveBarProgress {
+	background: #ffcc6a;
+}
+
 .steamdb_achievement_progress_compare .steamdb_achievement_progressbar_inner {
 	background: #8f723b;
 }

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -256,6 +256,7 @@ html {
 	flex-direction: column;
 	gap: 5px;
 	margin-left: auto;
+	text-align: right;
 	font-size: 12px;
 	font-weight: 400;
 	color: #8b929a;

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -274,7 +274,7 @@ html {
 }
 
 .steamdb_achievement_status_locked .steamdb_achievement_status_avatar {
-	opacity: .2;
+	opacity: 0.2;
 }
 
 .steamdb_achievement_status_row_compare {
@@ -342,7 +342,8 @@ html {
 	width: 0%;
 }
 
-.steamdb_achievement_progressbar.steamdb_achievement_progress_compare .achieveBarProgress,
+.steamdb_achievement_progressbar.steamdb_achievement_progress_compare
+	.achieveBarProgress,
 .steamdb_achievement_progress_compare .steamdb_achievement_progressbar_inner {
 	background: #ffcc6a;
 }


### PR DESCRIPTION
Hello, this enables SteamDB achievement enhancements on id|profile/\*/stats/\*/compare pages such as https://steamcommunity.com/id/ChetFaliszek/stats/383870/compare

It looks like this
![image](https://github.com/user-attachments/assets/23aa0650-b4a7-49cd-afb4-5f1bbfe868b9)


I tested it a little bit and it seems to work fine unless I'm missing some edge cases.

It works with progress bar achievements, assuming that original text for the second player is always something like "(14,035,100 / 50,000,000)". Unfortunately there is no progress info for the second player if the first one got the achievement already.

![image](https://github.com/user-attachments/assets/e9f8a992-6458-480e-9d1e-7480385de841)
