### PR TITLE
Hide second achievement image on mobile

### DIFF
--- a/scripts/community/achievements.js
+++ b/scripts/community/achievements.js
@@ -761,7 +761,7 @@ function InitAchievements( items, isPersonal )
 			{
 				const image = document.createElement( 'img' );
 				image.src = `${applicationConfig.MEDIA_CDN_COMMUNITY_URL}images/apps/${appid}/${player.unlockCompare ? achievement.icon : achievement.icon_gray}`;
-				image.className = 'steamdb_achievement_image';
+				image.className = 'steamdb_achievement_image steamdb_achievement_image_compare';
 				element.append( image );
 			}
 

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -417,4 +417,8 @@ html {
 		max-width: 200px;
 		width: 100%;
 	}
+
+	.steamdb_achievement_image_compare {
+		display: none;
+	}
 }


### PR DESCRIPTION
> Mobile view needs a bit of fixing.

Is hiding the second image for mobile a good solution? I think it's still easy to tell which achievements are locked/unlocked by looking at the avatar and text.