### PR TITLE
Show CS Rating history on CS2 achievements page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -381,6 +381,18 @@
 			]
 		},
 		{
+			"run_at": "document_end",
+			"matches":
+			[
+				"https://steamcommunity.com/id/*/stats/CSGO*",
+				"https://steamcommunity.com/profiles/*/stats/CSGO*"
+			],
+			"js":
+			[
+				"scripts/community/achievements_cs2.js"
+			]
+		},
+		{
 			"matches":
 			[
 				"https://steamcommunity.com/stats/*/achievements*"

--- a/scripts/community/achievements_cs2.js
+++ b/scripts/community/achievements_cs2.js
@@ -1,0 +1,112 @@
+/* global StartViewTransition */
+
+'use strict';
+
+const CreateCSRatingTable = ( rows ) =>
+{
+	const table = document.createElement( 'table' );
+	table.className = 'steamdb_achievements_csrating';
+
+	const thead = document.createElement( 'thead' );
+	table.append( thead );
+
+	const header = document.createElement( 'tr' );
+	thead.append( header );
+
+	const headerTdSeason = document.createElement( 'th' );
+	headerTdSeason.textContent = 'Season';
+	const headerTdDatetime = document.createElement( 'th' );
+	headerTdDatetime.textContent = 'Updated';
+	const headerTdCSR = document.createElement( 'th' );
+	headerTdCSR.textContent = 'CS Rating';
+	const headerTdCSRdelta = document.createElement( 'th' );
+	headerTdCSRdelta.textContent = 'Δ';
+	header.append( headerTdSeason, headerTdDatetime, headerTdCSR, headerTdCSRdelta );
+
+	let prevScore = 0;
+	for( let i = rows.length - 1; i >= 0; i-- )
+	{
+		if( prevScore !== 0 )
+		{
+			rows[ i ].delta = rows[ i ].csr - prevScore;
+		}
+		prevScore = rows[ i ].csr;
+	}
+
+	const dateFormatter = new Intl.DateTimeFormat( GetLanguage(), {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	} );
+
+	const tbody = document.createElement( 'tbody' );
+	table.append( tbody );
+
+	for( const row of rows )
+	{
+		const tr = document.createElement( 'tr' );
+		tbody.append( tr );
+
+		const season = document.createElement( 'td' );
+		season.textContent = `Season ${row.season}`;
+		tr.append( season );
+
+		const datetime = document.createElement( 'td' );
+		datetime.textContent = dateFormatter.format( new Date( row.datetime ).getTime() );
+		tr.append( datetime );
+
+		const csr = document.createElement( 'td' );
+		csr.textContent = row.csr;
+		const tier = Math.floor( row.csr / 5000 );
+		csr.className = `steamdb_achievements_csrating-value steamdb_achievements_csrating-tier${tier}`;
+		tr.append( csr );
+
+		const delta = document.createElement( 'td' );
+		delta.textContent = row.delta;
+		delta.className = row.delta > 0
+			? 'steamdb_achievements_csrating_positive'
+			: 'steamdb_achievements_csrating_negative';
+		tr.append( delta );
+	}
+
+	StartViewTransition( () =>
+	{
+		document.querySelector( '#mainContents' ).append( table );
+	} );
+};
+
+const FetchCSRating = async() =>
+{
+	const res = await fetch( 'https://steamcommunity.com/my/gcpd/730?tab=majors' );
+	const html = await res.text();
+
+	const parser = new DOMParser();
+	const dom = parser.parseFromString( html, 'text/html' );
+
+	const rows = [ ...dom.querySelectorAll( 'tr' ) ]
+		.filter( tr => tr.querySelector( 'td' )?.textContent.startsWith( 'premier' ) );
+
+	const premierRows = [];
+	for( const row of rows )
+	{
+		premierRows.push( {
+			season: row.querySelector( 'td' ).textContent.replace( 'premier_season', '' ),
+			datetime: row.querySelector( 'td:nth-child(2)' ).textContent,
+			csr: Number( row.querySelector( 'td:nth-child(3)' ).textContent ) >> 15,
+		} );
+	}
+
+	if( premierRows.length )
+	{
+		CreateCSRatingTable( premierRows );
+	}
+};
+
+const removeTrailingSlash = ( str ) => str.endsWith( '/' ) ? str.slice( 0, -1 ) : str;
+
+const viewingProfile = removeTrailingSlash( document.querySelector( '.pagecontent .persona_name_text_content' ).pathname );
+const myProfile = removeTrailingSlash( document.querySelector( '.user_avatar' ).pathname );
+
+if( viewingProfile === myProfile )
+{
+	FetchCSRating();
+}

--- a/styles/achievements.css
+++ b/styles/achievements.css
@@ -403,6 +403,79 @@ html {
 	opacity: 1;
 }
 
+.steamdb_achievements_csrating {
+	width: 100%;
+	border-spacing: 0;
+	border: solid 1px #2c405b;
+	color: #c6d4df;
+	background-color: #1b2838;
+}
+
+.steamdb_achievements_csrating-value {
+	font-weight: bold;
+}
+
+.steamdb_achievements_csrating-tier0 {
+	color: #b0c3d9;
+}
+
+.steamdb_achievements_csrating-tier1 {
+	color: #8cc6ff;
+}
+
+.steamdb_achievements_csrating-tier2 {
+	color: #6a7dff;
+}
+
+.steamdb_achievements_csrating-tier3 {
+	color: #c166ff;
+}
+
+.steamdb_achievements_csrating-tier4 {
+	color: #f03cff;
+}
+
+.steamdb_achievements_csrating-tier5 {
+	color: #eb4b4b;
+}
+
+.steamdb_achievements_csrating-tier6 {
+	color: #ffd700;
+}
+
+.steamdb_achievements_csrating tr {
+	height: 50px;
+}
+
+.steamdb_achievements_csrating tr:nth-child(odd) {
+	background-color: rgb(0 0 0 / 20%);
+}
+
+.steamdb_achievements_csrating tr:hover {
+	background-color: rgb(255 255 255 / 20%);
+}
+
+.steamdb_achievements_csrating th {
+	background-color: #0197cf;
+}
+
+.steamdb_achievements_csrating th,
+.steamdb_achievements_csrating td {
+	text-align: center;
+}
+
+.steamdb_achievements_csrating_negative {
+	color: red;
+}
+
+.steamdb_achievements_csrating_positive {
+	color: green;
+}
+
+.steamdb_achievements_csrating_positive::before {
+	content: "+";
+}
+
 @media (max-width: 600px) {
 	.steamdb_achievements_title {
 		flex-flow: row wrap;


### PR DESCRIPTION
Feel free to quickly reject this :)
There may be too much data in the future or Valve changes https://steamcommunity.com/my/gcpd/730?tab=majors page.

But it seems to work now and shouldn't break anything if it fails. It works only on your own page obviously.

![image](https://github.com/user-attachments/assets/55fd104e-c55a-466f-b574-902805d30541)