### PR TITLE
Remove default horizontal margins from slider, make title appear clickable and limit its width

### DIFF
--- a/scripts/community/achievements_cs2.js
+++ b/scripts/community/achievements_cs2.js
@@ -333,7 +333,7 @@ const FetchCSRating = async( profileUrl ) =>
 	summary.className = 'steamdb_achievements_title';
 
 	const summaryName = document.createElement( 'summary' );
-	summaryName.className = 'steamdb_achievements_game_name';
+	summaryName.className = 'steamdb_achievements_game_name steamdb_achievements_csrating_fold';
 	summaryName.textContent = _t( 'achievements_csrating_name' );
 	summary.append( summaryName );
 

--- a/styles/achievements_cs2.css
+++ b/styles/achievements_cs2.css
@@ -7,6 +7,11 @@
 	font-variant-numeric: tabular-nums;
 }
 
+.steamdb_achievements_csrating_fold {
+	cursor: pointer;
+	width: fit-content;
+}
+
 .steamdb_achievements_csrating-value {
 	font-weight: bold;
 }
@@ -54,6 +59,7 @@
 	color-scheme: dark;
 	direction: rtl;
 	width: 100%;
+	margin: 2px 0;
 }
 
 .community_tooltip.steamdb_achievements_csrating_graph_tooltip {


### PR DESCRIPTION
Slider was slightly misaligned because of default user agent margins

![slider_margin](https://github.com/user-attachments/assets/9130f2f2-6bb0-4732-aa91-ef3429f05b9b)