### PR TITLE
Add ajax=1 parameter to query string for fetching CS Rating

### DIFF
--- a/scripts/community/achievements_cs2.js
+++ b/scripts/community/achievements_cs2.js
@@ -299,11 +299,11 @@ const CreateCSRatingTable = ( container, rows ) =>
 
 const FetchCSRating = async( profileUrl ) =>
 {
-	const res = await fetch( `https://steamcommunity.com${profileUrl}/gcpd/730?tab=majors` );
-	const html = await res.text();
+	const res = await fetch( `https://steamcommunity.com${profileUrl}/gcpd/730?tab=majors&ajax=1` );
+	const json = await res.json();
 
 	const parser = new DOMParser();
-	const dom = parser.parseFromString( html, 'text/html' );
+	const dom = parser.parseFromString( json.html, 'text/html' );
 
 	const rows = [ ...dom.querySelectorAll( 'tr' ) ]
 		.filter( tr => tr.querySelector( 'td' )?.textContent.startsWith( 'premier' ) );


### PR DESCRIPTION
This reduced response from 16.4kB to 6.5kB in my case.

Found this parameter by trying to fetch exact match corresponding to the score, it's used on https://steamcommunity.com/my/gcpd/730?tab=matchhistorypremier and other pages, so I tried it on the ```majors``` tab and it works!

---
Unrelated to the pull request:

About fetching the exact match, when you click "Load More History" on the page above, it sends request with parameters ```ajax=1&tab=matchhistorypremier&continue_token=3706564936885862400```, I figured out that ```continue_token``` is a timestamp in seconds in an unusual format

```
3706564936885862400n >> 31n // 1726003800 which is 2024-09-10T21:30:00.000Z

// to get continue_token for any timestamp:
const timestamp = new Date('2024-08-12 00:00:00 GMT').getTime();
const timestampInSeconds = timestamp / 1000; // 1723420800
const continueToken = (BigInt(timestampInSeconds) << 31n).toString(); // 3701017986623078400
```

Sending request with this token returns a week of matches before it. So I used this conversion for the Score date, thinking that surely the match time should be just before the score was updated. And it works fine most of the time


https://github.com/user-attachments/assets/f17c8536-62ec-4dac-996b-61cbef20e643



But then sometimes it doesn't and needs the time to be a bit earlier, I think it happens because this request respects the parameter but doesn't return 7 days of matches before it but instead limits it with the end of a week (and I'm pretty sure it's a CS2 week, where it ends on Wednesday when the drops reset, didn't investigate the exact time, just my problematic matches occurred on Wednesdays). So when you start a match before this time but your score is updated after (and we use the time of a score updating) it will return nothing.

This can be worked around of course, fetch again with earlier time if nothing is returned... But at this point I decided that it's not worth it.

- Returned table is not localized on Steam (except "Download Replay" and "Premier"), so it would need a lot of translations.
- It doesn't have Damage Dealt column that is now so prominent in CS2.
- To be efficient, we would need to use all the data that was returned by this request, matching times of matches with times of scores (in my prototype I always use the first row and discard everything else).
- What if a player is kicked, finds a new match and finishes it before the first one ended, would the dates of matches and scores be out of order?

Anyway... I decided to write this mostly to document what that continue_token represents and how to convert between it and a timestamp.
