### PR TITLE
Move max tier label below the line if it's close to the top, don't show 0k

### DIFF
--- a/scripts/community/achievements_cs2.js
+++ b/scripts/community/achievements_cs2.js
@@ -138,29 +138,23 @@ const DrawChart = ( initialData, hoveredIndex, canvas, tooltip, maxLength ) =>
 	ctx.fill();
 
 	// Max tier dashed line
-	let maxCSRClean = maxCSR - ( maxCSR % 5000 );
-	let maxCSRTier = 2 * ( maxCSRClean / maxCSR - 0.5 );
-	let maxCSRTierY = ( -maxCSRTier * paddedHeight ) / 2 + halfHeight;
 	ctx.strokeStyle = '#424857';
 	ctx.lineWidth = 1 * devicePixelRatio;
 	ctx.setLineDash( [ 7 * devicePixelRatio, 4 * devicePixelRatio ] );
-	ctx.beginPath();
-	ctx.moveTo( 0, maxCSRTierY );
-	ctx.lineTo( width, maxCSRTierY );
-	ctx.stroke();
-
 	ctx.fillStyle = '#999';
-	ctx.fillText( `${( maxCSRClean / 1000 ).toFixed( 0 )}k`, 0, maxCSRTierY - 4 );
 
-	maxCSRClean -= 5000;
-	maxCSRTier = 2 * ( maxCSRClean / maxCSR - 0.5 );
-	maxCSRTierY = ( -maxCSRTier * paddedHeight ) / 2 + halfHeight;
-	ctx.beginPath();
-	ctx.moveTo( 0, maxCSRTierY );
-	ctx.lineTo( width, maxCSRTierY );
-	ctx.stroke();
+	for( let maxCSRClean = maxCSR - ( maxCSR % 5000 ), i = 0; maxCSRClean >= 5000 && i < 2; maxCSRClean -= 5000, i++ )
+	{
+		const maxCSRTier = 2 * ( maxCSRClean / maxCSR - 0.5 );
+		const maxCSRTierY = ( -maxCSRTier * paddedHeight ) / 2 + halfHeight;
 
-	ctx.fillText( `${( maxCSRClean / 1000 ).toFixed( 0 )}k`, 0, maxCSRTierY - 4 );
+		ctx.beginPath();
+		ctx.moveTo( 0, maxCSRTierY );
+		ctx.lineTo( width, maxCSRTierY );
+		ctx.stroke();
+
+		ctx.fillText( `${( maxCSRClean / 1000 ).toFixed( 0 )}k`, 0,	maxCSRTierY < 12 ? maxCSRTierY + 12 : maxCSRTierY - 4 );
+	}
 
 	ctx.setLineDash( [] );
 


### PR DESCRIPTION
Got 15k for the first time and text didn't fit.
![2024-09-16 201114](https://github.com/user-attachments/assets/b5b48ea6-6daf-4287-87a9-63931b95b104)

Looks like this after the change
![2024-09-16 214856](https://github.com/user-attachments/assets/f491bc12-7b52-4b77-8339-6450668df708)

Also moved tier lines into a loop so code doesn't repeat, can change ```i < 2``` to draw more tiers or remove to draw all tiers. And don't show 0k line (can't lose CSR below 4k afaik).