### PR TITLE
Grab Family Sharing data from Steam & show flag on Steam Store

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -457,6 +457,9 @@
 	"options_website_highlight3": {
 		"message": "Enable extra filtering on <a href=\"https://steamdb.info/sales/\" target=\"_blank\">sales page</a> and <a href=\"https://steamdb.info/bundles/\" target=\"_blank\">bundles page</a>"
 	},
+	"options_website_family": {
+		"message": "Highlight family owned apps"
+	},
 
 	"options_extra_data": {
 		"message": "Extra data fetched from $domain$",

--- a/options/options.html
+++ b/options/options.html
@@ -73,6 +73,10 @@
 					<input type="checkbox" class="option-check" checked disabled>
 					<div data-msg="options_website_highlight3"></div>
 				</div>
+				<div class="checkbox">
+					<input type="checkbox" class="option-check" data-option="steamdb-highlight-family" checked>
+					<div data-msg="options_website_family"></div>
+				</div>
 			</div>
 		</div>
 

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -191,9 +191,10 @@ async function FetchSteamUserFamilyData( callback )
 
 			const paramsSharedLibrary = new URLSearchParams();
 			paramsSharedLibrary.set( 'access_token', response.data.webapi_token );
-			paramsSharedLibrary.set( 'include_free', 'true' );
 			paramsSharedLibrary.set( 'family_groupid', '0' );
 			paramsSharedLibrary.set( 'include_own', 'true' );
+			paramsSharedLibrary.set( 'include_excluded', 'true' );
+			paramsSharedLibrary.set( 'include_free', 'true' );
 			paramsSharedLibrary.set( 'include_non_games', 'true' );
 			// family_groupid is ignored
 			// the include_own param has no link with its name, if set at false, it returns only your owned apps, if set at true, it returns your owned apps and the apps from your family
@@ -212,7 +213,10 @@ async function FetchSteamUserFamilyData( callback )
 					{
 						if( !app.owner_steamids.includes( response.response.owner_steamid ) )
 						{
-							data.left.push( app.appid );
+							if( app.exclude_reason === 0 )
+							{
+								data.left.push( app.appid );
+							}
 						}
 						else
 						{
@@ -225,6 +229,7 @@ async function FetchSteamUserFamilyData( callback )
 							rgFamilySharedApps: reduced.left,
 							rgOwnedApps: reduced.right,
 						};
+					console.log( userFamilyDataCache );
 
 					callback( { data: userFamilyDataCache } );
 

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -221,13 +221,20 @@ async function FetchSteamUserFamilyData( callback )
 					}
 					const reduced = response.response.apps.reduce( ( data, app ) =>
 					{
-						data.push( { appid: app.appid, owner_steamids: app.owner_steamids } );
+						if( !app.owner_steamids.includes( response.response.owner_steamid ) )
+						{
+							data.left.push( app.appid );
+						}
+						else
+						{
+							data.right.push( app.appid );
+						}
 						return data;
-					}, [] );
+					}, { left: [], right: [] }  );
 					userFamilyDataCache =
 						{
-							rgFamilySharedApps: reduced,
-							owner_steamid: response.response.owner_steamid,
+							rgFamilySharedApps: reduced.left,
+							rgOwnedApps: reduced.right,
 						};
 
 					callback( { data: userFamilyDataCache } );

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -91,7 +91,7 @@ function FetchSteamUserData( callback )
 		return;
 	}
 
-	GetLocalOption( { 'userdata.cached': Date.now() }, ( data ) =>
+	GetLocalOption( { 'userdata.cached': Date.now() } ).then( ( data ) =>
 	{
 		const now = Date.now();
 		let cache = data[ 'userdata.cached' ];
@@ -146,7 +146,7 @@ function FetchSteamUserData( callback )
 			{
 				InvalidateCache();
 
-				GetLocalOption( { 'userdata.stored': false }, ( data ) =>
+				GetLocalOption( { 'userdata.stored': false } ).then( ( data ) =>
 				{
 					const response =
 					{
@@ -174,7 +174,7 @@ async function FetchSteamUserFamilyData( callback )
 	const now = Date.now();
 	let cache;
 
-	await GetLocalOption( { 'userfamilydata.stored': false }, ( data ) =>
+	await GetLocalOption( { 'userfamilydata.stored': false } ).then( ( data ) =>
 	{
 		cache = JSON.parse( data[ 'userfamilydata.stored' ] );
 	} );
@@ -667,9 +667,9 @@ function GetStoreSessionID( isCheckout, callback )
 		.catch( ( error ) => callback( { success: false, error: error.message } ) );
 }
 
-function GetLocalOption( items, callback )
+function GetLocalOption( items )
 {
-	return ExtensionApi.storage.local.get( items ).then( callback );
+	return ExtensionApi.storage.local.get( items );
 }
 
 function SetLocalOption( option, value )

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -172,9 +172,8 @@ async function FetchSteamUserFamilyData( callback )
 		return;
 	}
 	const now = Date.now();
-	let cache;
 
-	await GetLocalOption( { 'userfamilydata.stored': false } ).then( ( data ) =>
+	let cache = await GetLocalOption( { 'userfamilydata.stored': false } ).then( ( data ) =>
 	{
 		cache = JSON.parse( data[ 'userfamilydata.stored' ] );
 	} );

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -66,21 +66,16 @@ ExtensionApi.runtime.onMessage.addListener( ( request, sender, callback ) =>
 	return false;
 } );
 
-function InvalidateCache( target = null )
+function InvalidateCache()
 {
-	if( target === null || target === 'userdata' )
-	{
-		userDataCache = null;
 
-		SetLocalOption( 'userdata.cached', Date.now() );
-	}
+	userDataCache = null;
 
-	if( target === null || target === 'userfamilydata' )
-	{
-		userFamilyDataCache = null;
+	SetLocalOption( 'userdata.cached', Date.now() );
 
-		SetLocalOption( 'userfamilydata.stored', '' );
-	}
+	userFamilyDataCache = null;
+
+	SetLocalOption( 'userfamilydata.stored', '' );
 }
 
 function FetchSteamUserData( callback )
@@ -242,9 +237,6 @@ async function FetchSteamUserFamilyData( callback )
 				} );
 		} ).catch( ( error ) =>
 		{
-
-			InvalidateCache( 'userfamilydata' );
-
 			const response =
 				{
 					error: error.message,

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -68,7 +68,6 @@ ExtensionApi.runtime.onMessage.addListener( ( request, sender, callback ) =>
 
 function InvalidateCache()
 {
-
 	userDataCache = null;
 
 	SetLocalOption( 'userdata.cached', Date.now() );
@@ -168,10 +167,8 @@ async function FetchSteamUserFamilyData( callback )
 	}
 	const now = Date.now();
 
-	let cache = await GetLocalOption( { 'userfamilydata.stored': false } ).then( ( data ) =>
-	{
-		cache = JSON.parse( data[ 'userfamilydata.stored' ] );
-	} );
+	const cache = await GetLocalOption( { 'userfamilydata.stored': false } )
+		.then( ( data ) => data[ 'userfamilydata.stored' ] ?? JSON.parse( data[ 'userfamilydata.stored' ] ) );
 
 	if( cache && cache.cached && cache.data && now < cache.cached + 3600000 )
 	{
@@ -192,10 +189,8 @@ async function FetchSteamUserFamilyData( callback )
 				throw new Error( 'Are you logged on the Steam Store in this browser?' );
 			}
 
-			const accessToken = response.data.webapi_token;
-
 			const paramsSharedLibrary = new URLSearchParams();
-			paramsSharedLibrary.set( 'access_token', accessToken );
+			paramsSharedLibrary.set( 'access_token', response.data.webapi_token );
 			paramsSharedLibrary.set( 'include_free', 'true' );
 			paramsSharedLibrary.set( 'family_groupid', '0' );
 			paramsSharedLibrary.set( 'include_own', 'true' );

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -121,7 +121,7 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 			if( UserFamilyData.data )
 			{
 				response.rgFamilySharedApps =  UserFamilyData.data?.rgFamilySharedApps;
-				if( UserFamilyData.data?.rgOwnedPackages )
+				if( UserFamilyData.data?.rgOwnedApps )
 				{
 					response.rgOwnedApps = [ ... new Set( [ ...response.rgOwnedApps, ...UserFamilyData.data.rgOwnedApps ] ) ];
 				}

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -127,18 +127,12 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 		}
 		if( UserData.data && UserFamilyData.data )
 		{
-			response.rgFamilySharedApps =  UserFamilyData.data?.rgFamilySharedApps.reduce( ( data, app ) =>
+
+			response.rgFamilySharedApps =  UserFamilyData.data?.rgFamilySharedApps;
+			if( UserFamilyData.data?.rgOwnedPackages )
 			{
-				if( !app.owner_steamids.includes( UserFamilyData.data?.owner_steamid ) )
-				{
-					data.push( app.appid );
-				}
-				else if( !response.rgOwnedApps[ app.appid ] )
-				{
-					response.rgOwnedApps.push( app.appid );
-				}
-				return data;
-			}, [] );
+				response.rgOwnedApps = [ ... new Set( [ ...response.rgOwnedApps, ...UserFamilyData.data.rgOwnedApps ] ) ];
+			}
 			log.push( `Family Apps: ${response.rgFamilySharedApps.length}` );
 		}
 

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -94,20 +94,22 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 		} ),
 	] ).then( ( responses ) =>
 	{
-		if( responses[ 0 ]?.error )
+		const { UserData, UserFamilyData } = responses;
+
+		if( UserData?.error )
 		{
-			WriteLog( 'Failed to load userdata', responses[ 0 ].error );
+			WriteLog( 'Failed to load userdata', UserData.error );
 		}
 
-		if( responses[ 1 ]?.error )
+		if( UserFamilyData?.error )
 		{
-			if( responses[ 1 ].error === 'You are not part of any family group.' )
+			if( UserFamilyData.error === 'You are not part of any family group.' )
 			{
-				WriteLog( responses[ 1 ].error );
+				WriteLog( UserFamilyData.error );
 			}
 			else
 			{
-				WriteLog( 'Failed to load family userdata', responses[ 1 ].error );
+				WriteLog( 'Failed to load family userdata', UserFamilyData.error );
 
 				// window.postMessage( {
 				// 	version: EXTENSION_INTEROP_VERSION,
@@ -118,16 +120,16 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 		}
 		let response;
 		const log = [];
-		if( responses[ 0 ].data )
+		if( UserData.data )
 		{
-			response = responses[ 0 ].data;
+			response = UserData.data;
 			log.push( `Packages: ${response.rgOwnedPackages.length}` );
 		}
-		if( responses[ 0 ].data && responses[ 1 ].data )
+		if( UserData.data && UserFamilyData.data )
 		{
-			response.rgFamilySharedApps =  responses[ 1 ].data?.rgFamilySharedApps.reduce( ( data, app ) =>
+			response.rgFamilySharedApps =  UserFamilyData.data?.rgFamilySharedApps.reduce( ( data, app ) =>
 			{
-				if( !app.owner_steamids.includes( responses[ 1 ].data?.owner_steamid ) )
+				if( !app.owner_steamids.includes( UserFamilyData.data?.owner_steamid ) )
 				{
 					data.push( app.appid );
 				}

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -61,7 +61,7 @@ window.addEventListener( 'message', ( request ) =>
 	}
 } );
 
-GetOption( { 'steamdb-highlight': true }, ( items ) =>
+GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( items ) =>
 {
 	if( !items[ 'steamdb-highlight' ] )
 	{
@@ -77,12 +77,6 @@ GetOption( { 'steamdb-highlight': true }, ( items ) =>
 			if( response.error )
 			{
 				WriteLog( 'Failed to load userdata', response.error );
-
-				window.postMessage( {
-					version: EXTENSION_INTEROP_VERSION,
-					type: 'steamdb:extension-error',
-					error: `Failed to load your games. ${response.error}`,
-				}, GetHomepage() );
 			}
 
 			if( response.data )
@@ -106,10 +100,7 @@ GetOption( { 'steamdb-highlight': true }, ( items ) =>
 			OnPageLoaded();
 		}
 	} );
-} );
 
-GetOption( { 'steamdb-highlight-family': true }, ( items ) =>
-{
 	if( !items[ 'steamdb-highlight-family' ] )
 	{
 		return;

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -94,7 +94,7 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 		} ),
 	] ).then( ( responses ) =>
 	{
-		const { UserData, UserFamilyData } = responses;
+		const [ UserData, UserFamilyData ] = responses;
 
 		if( UserData?.error )
 		{

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -82,8 +82,7 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 		{
 			if( !items[ 'steamdb-highlight-family' ] )
 			{
-				// ! this is probably a bad idea maybe returning an empty object is better
-				resolve( null );
+				resolve( {} );
 			}
 			SendMessageToBackgroundScript( {
 				contentScriptQuery: 'FetchSteamUserFamilyData',
@@ -110,12 +109,6 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 			else
 			{
 				WriteLog( 'Failed to load family userdata', UserFamilyData.error );
-
-				// window.postMessage( {
-				// 	version: EXTENSION_INTEROP_VERSION,
-				// 	type: 'steamdb:extension-error',
-				// 	error: `Failed to load your family games. ${response.error}`,
-				// }, GetHomepage() );
 			}
 		}
 		let response;
@@ -124,16 +117,16 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, ( it
 		{
 			response = UserData.data;
 			log.push( `Packages: ${response.rgOwnedPackages.length}` );
-		}
-		if( UserData.data && UserFamilyData.data )
-		{
 
-			response.rgFamilySharedApps =  UserFamilyData.data?.rgFamilySharedApps;
-			if( UserFamilyData.data?.rgOwnedPackages )
+			if( UserFamilyData.data )
 			{
-				response.rgOwnedApps = [ ... new Set( [ ...response.rgOwnedApps, ...UserFamilyData.data.rgOwnedApps ] ) ];
+				response.rgFamilySharedApps =  UserFamilyData.data?.rgFamilySharedApps;
+				if( UserFamilyData.data?.rgOwnedPackages )
+				{
+					response.rgOwnedApps = [ ... new Set( [ ...response.rgOwnedApps, ...UserFamilyData.data.rgOwnedApps ] ) ];
+				}
+				log.push( `Family Apps: ${response.rgFamilySharedApps.length}` );
 			}
-			log.push( `Family Apps: ${response.rgFamilySharedApps.length}` );
 		}
 
 		const OnPageLoaded = () =>


### PR DESCRIPTION
"Small" pr to pull Steam family Library share info & store it while removing what isn't essential
It also adds a flag to apps that are in your family share (but that don't already have a flag for ownership (we're processing the data we receive to exclude apps we own but we never know) or wishlist. This is done in different way depending on what page we're on: generic (includes the search bar), wishlist (until it get react-ified) or react. (fwiw, whenever wishlist switches to react, it should switch by itself to the react code path)
Since we're grabbing an access token from steam (and that it leaking has inherent risk), it seemed better to put the option that controls this functionality under a new `<detail>` category (although it can be kinda weird since we're mentioning pulling data from the website we're on, which can kinda be expected...)
I've kept the family svg as reference but it can most likely be dropped before merge (source is this (non working since file too big) link <https://github.com/SteamDatabase/SteamTracking/blob/6d14c50c25b15afdcfeb15bde2116d817e5bc042/store.steampowered.com/public/javascript/applications/store/main.js#L96887>)

TODO:
- ~~handle not being in a family better~~ didn't test the code for this
- ~~gate this behind an option checkbox~~
- ~~display info in steam's store search page ? (.ds_flagged .ds_owned)~~ ~~still needs to work on react pages~~ should work in every possible case
- ~~maybe there a cleaner way to grab the steamid than via the token~~
- ~~reduce GetSharedLibraryApps in an object instead of an array to have appid as keys & owner_steamids as value (not sure if there's any value in doing that)~~
- ~~look into removing having family sharing info on free app seems weird but when i last checked, include_free at false still returned free app~~ include_free doesn't change anything no matter the value
- ~~look into handling excluded apps (there most likely a way to know if they're excluded by an adult vs devs)~~ include_excluded doesn't return anything valuable, it returns apps where dev opted-out but no info on private app/app limited by an adult

<details>
  <summary>Send Pics</summary>
  
![image](https://github.com/user-attachments/assets/a397fa37-5a7d-45f5-b9ea-26a8dfffdb50)
![image](https://github.com/user-attachments/assets/fea35a08-ac2c-4f88-a56f-a03d68494c83)
![image](https://github.com/user-attachments/assets/dab5db43-57d9-4208-8585-32cd0b664b74)
![image](https://github.com/user-attachments/assets/118367b0-c9ca-4901-aee2-e532d064166f)
![image](https://github.com/user-attachments/assets/f075caaa-d651-4e8d-aa94-431a9567751b)
![image](https://github.com/user-attachments/assets/09596910-2490-4771-9695-d5c644b5c350)

</details>