### PR TITLE
Add handling of private apps data

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -56,6 +56,7 @@ ExtensionApi.runtime.onMessage.addListener( ( request, sender, callback ) =>
 		case 'GetApp': GetApp( request.appid, callback ); return true;
 		case 'GetAppPrice': GetAppPrice( request, callback ); return true;
 		case 'GetAchievementsGroups': GetAchievementsGroups( request.appid, callback ); return true;
+		case 'SetAppPrivate': SetAppPrivate( request.appids, request.private, callback ); return true;
 		case 'StoreWishlistAdd': StoreWishlistAdd( request.appid, callback ); return true;
 		case 'StoreWishlistRemove': StoreWishlistRemove( request.appid, callback ); return true;
 		case 'StoreFollow': StoreFollow( request.appid, callback ); return true;
@@ -482,6 +483,27 @@ function GetAchievementsGroups( appid, callback )
 		.then( GetJsonWithStatusCheck )
 		.then( callback )
 		.catch( ( error ) => callback( { success: false, error: error.message } ) );
+}
+
+/**
+ * @param {Array<Number>} appids
+ * @param {Boolean} privateState
+ * @param {Function} callback
+ */
+// ? Api supports setting multiple apps at once (Are they even using that feature?), do we really need that?
+async function SetAppPrivate( appids, privateState, callback )
+{
+	const token = await GetStoreToken();
+	const paramsSetPrivate = new URLSearchParams();
+	paramsSetPrivate.set( 'access_token', token );
+	appids.forEach( ( appid, index ) =>
+	{
+		paramsSetPrivate.set( `appids[${index}]`, appid );
+	} );
+	paramsSetPrivate.set( 'private', privateState );
+	const responseFetch = await fetch(
+		`https://api.steampowered.com/IAccountPrivateAppsService/ToggleAppPrivacy/v1/?${paramsSetPrivate.toString()}`
+	);
 }
 
 /**

--- a/scripts/steamdb/global.js
+++ b/scripts/steamdb/global.js
@@ -81,6 +81,14 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, asyn
 	} );
 
 	/** @type {Promise<{data?: object, error?: string}>} */
+	const PrivateDataPromise = new Promise( ( resolve ) =>
+	{
+		SendMessageToBackgroundScript( {
+			contentScriptQuery: 'FetchPrivateApps',
+		}, resolve );
+	} );
+
+	/** @type {Promise<{data?: object, error?: string}>} */
 	const familyDataPromise = new Promise( ( resolve ) =>
 	{
 		if( !items[ 'steamdb-highlight-family' ] )
@@ -103,7 +111,7 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, asyn
 		}, 10000 ); // 10 seconds
 	} );
 
-	const userData = await userDataPromise;
+	const [ userData, privateData ] = await Promise.all( [ userDataPromise, PrivateDataPromise ] );
 
 	// If family data does not load fast enough, assume it failed
 	const familyData = await Promise.race( [
@@ -114,6 +122,11 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, asyn
 	if( userData.error )
 	{
 		WriteLog( 'Failed to load userdata', userData.error );
+	}
+
+	if( privateData.error )
+	{
+		WriteLog( 'Failed to load privatedata', privateData.error );
 	}
 
 	if( familyData.error )
@@ -127,6 +140,11 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, asyn
 	if( userData.data )
 	{
 		response = userData.data;
+
+		if( privateData.data )
+		{
+			response.rgPrivateApps = privateData.data.rgPrivateApps;
+		}
 
 		if( familyData.data )
 		{
@@ -159,6 +177,8 @@ GetOption( { 'steamdb-highlight': true, 'steamdb-highlight-family': true }, asyn
 				beforeDom ? '(before dom completed)' : '',
 				'Packages',
 				response.rgOwnedPackages?.length || 0,
+				'Private Apps',
+				response.rgPrivateApps?.length || 0,
 				'Family Apps',
 				response.rgFamilySharedApps?.length || 0,
 			);


### PR DESCRIPTION
Moved fetching the store token to its own function to dedup but i'm not sure if storing it in local storage should be kept, do we trust users enough to not get it stolen?
I've tested FetchPrivateApps but not SetAppPrivate
I haven't gated this behind an option since, depending of what's made of this, the fetch would fit under "Enable extra filtering on sales page and bundles page" and the set under "Wishlist, follow, and ignore products on the Steam store directly from SteamDB"