### PR TITLE
Add ability to reveal spoilers on guide pages

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -363,6 +363,10 @@
 		"message": "No badge crafted"
 	},
 
+	"spoilers_reveal": {
+		"message": "Reveal spoilers",
+		"description": "A button or checkbox that reveals spoilers when toggled"
+	},
 
 	"options": {
 		"message": "Options"

--- a/manifest.json
+++ b/manifest.json
@@ -101,6 +101,7 @@
 		},
 		{
 			"run_at": "document_start",
+			"all_frames": true,
 			"matches":
 			[
 				"https://store.steampowered.com/*",
@@ -494,6 +495,18 @@
 			"js":
 			[
 				"scripts/community/filedetails.js"
+			]
+		},
+		{
+			"all_frames": true,
+			"matches":
+			[
+				"https://steamcommunity.com/sharedfiles/filedetails*",
+				"https://steamcommunity.com/workshop/filedetails*"
+			],
+			"js":
+			[
+				"scripts/community/filedetails_guide.js"
 			]
 		},
 		{

--- a/scripts/community/filedetails_guide.js
+++ b/scripts/community/filedetails_guide.js
@@ -1,0 +1,40 @@
+'use strict';
+
+if( document.querySelector( '.guideTopContent' ) )
+{
+	const guide = document.querySelector( '.guide' );
+	const spoilers = guide.querySelectorAll( '.bb_spoiler' );
+
+	if( spoilers.length > 0 )
+	{
+		const controls = document.querySelector( '#ItemControls' );
+
+		const divider = document.createElement( 'div' );
+		divider.className = 'vertical_divider';
+		controls.append( divider );
+
+		const checkboxWrapper = document.createElement( 'label' );
+		checkboxWrapper.textContent = _t( 'spoilers_reveal' );
+		checkboxWrapper.className = 'workshopItemControlCtn general_btn';
+
+		const checkbox = document.createElement( 'input' );
+		checkbox.type = 'checkbox';
+		checkbox.style.display = 'none';
+		checkboxWrapper.prepend( checkbox );
+		controls.append( checkboxWrapper );
+
+		checkbox.addEventListener( 'change', event =>
+		{
+			const reveal = event.target.checked;
+
+			checkboxWrapper.style.backgroundColor = reveal ? '#2d6bcd' : '';
+			checkboxWrapper.style.color = reveal ? '#fff' : '';
+
+			for( const spoiler of spoilers )
+			{
+				spoiler.classList.toggle( 'steamdb_spoiler_revealed', reveal );
+				spoiler.classList.toggle( 'bb_spoiler', !reveal );
+			}
+		} );
+	}
+}

--- a/scripts/community/filedetails_guide.js
+++ b/scripts/community/filedetails_guide.js
@@ -3,10 +3,31 @@
 if( document.querySelector( '.guideTopContent' ) )
 {
 	const guide = document.querySelector( '.guide' );
-	const spoilers = guide.querySelectorAll( '.bb_spoiler' );
 
-	if( spoilers.length > 0 )
+	if( guide.querySelector( '.bb_spoiler' ) )
 	{
+		const StartViewTransition = ( callback ) =>
+		{
+			if( document.startViewTransition )
+			{
+				document.startViewTransition( () =>
+				{
+					try
+					{
+						callback();
+					}
+					catch( e )
+					{
+						console.error( e );
+					}
+				} );
+			}
+			else
+			{
+				callback();
+			}
+		};
+
 		const controls = document.querySelector( '#ItemControls' );
 
 		const divider = document.createElement( 'div' );
@@ -16,25 +37,32 @@ if( document.querySelector( '.guideTopContent' ) )
 		const checkboxWrapper = document.createElement( 'label' );
 		checkboxWrapper.textContent = _t( 'spoilers_reveal' );
 		checkboxWrapper.className = 'workshopItemControlCtn general_btn';
+		checkboxWrapper.style.gap = '5px';
 
 		const checkbox = document.createElement( 'input' );
 		checkbox.type = 'checkbox';
-		checkbox.style.display = 'none';
+		checkbox.style.colorScheme = 'dark';
+		checkbox.style.margin = 0;
+		checkbox.style.cursor = 'pointer';
 		checkboxWrapper.prepend( checkbox );
 		controls.append( checkboxWrapper );
 
 		checkbox.addEventListener( 'change', event =>
 		{
+			const spoilers = guide.querySelectorAll( '.bb_spoiler,.steamdb_spoiler_revealed' );
 			const reveal = event.target.checked;
 
 			checkboxWrapper.style.backgroundColor = reveal ? '#2d6bcd' : '';
 			checkboxWrapper.style.color = reveal ? '#fff' : '';
 
-			for( const spoiler of spoilers )
+			StartViewTransition( () =>
 			{
-				spoiler.classList.toggle( 'steamdb_spoiler_revealed', reveal );
-				spoiler.classList.toggle( 'bb_spoiler', !reveal );
-			}
+				for( const spoiler of spoilers )
+				{
+					spoiler.classList.toggle( 'steamdb_spoiler_revealed', reveal );
+					spoiler.classList.toggle( 'bb_spoiler', !reveal );
+				}
+			} );
 		} );
 	}
 }


### PR DESCRIPTION
Some guides use a lot of spoilers, and I usually open them after completing the game, googled and found other people also wanting to remove them, so this could be a useful feature for some. For example https://steamcommunity.com/sharedfiles/filedetails/?id=3086907329

I had to add `"all_frames": true`  into manifest so it works from iframes (if you or a friend add a guide to their favorites, it appers in the Activity feed and opens in a frame there).
Also had to add it to the `common.js` file so that the `_t` function is available, not sure if this can cause any issues.

"spoilers_reveal" is a bit generic name, but may be reused later if this functionality extends to release notes, comments, etc.

The button only appears if there is at least one spoiler present.

Looks like this


https://github.com/user-attachments/assets/11c6ccdd-b18a-48b4-86b7-a624ac5df5af


