### PR TITLE
Fix SteamDB rating

### DIFF
--- a/scripts/store/app.js
+++ b/scripts/store/app.js
@@ -305,8 +305,8 @@ else
 
 			if( positiveVoteText && negativeVoteText )
 			{
-				const positiveVotes = Number.parseInt( positiveVoteText.textContent.replace( /[(.,)]/g, '' ), 10 );
-				const totalVotes = positiveVotes + Number.parseInt( negativeVoteText.textContent.replace( /[(.,)]/g, '' ), 10 );
+				const positiveVotes = Number.parseInt( positiveVoteText.textContent.replace( /[(.,\s)]/g, '' ), 10 );
+				const totalVotes = positiveVotes + Number.parseInt( negativeVoteText.textContent.replace( /[(.,\s)]/g, '' ), 10 );
 				const average = positiveVotes / totalVotes;
 				const score = average - ( average - 0.5 ) * ( 2 ** -Math.log10( totalVotes + 1 ) );
 


### PR DESCRIPTION
A recent Steam update changed the thousands separator in the Russian (and possibly other) localization, now a space is used as it should. This broke the parsing of numbers when calculating the rating.
Screenshots are taken on the [Signalis](https://store.steampowered.com/app/1262350/SIGNALIS/) page.
<img width="228" height="134" alt="chrome_2025-08-19_15-47-08" src="https://github.com/user-attachments/assets/94dad31b-2a2e-4d93-be44-f070d19b5ac1" />

## Before
<img width="293" height="99" alt="chrome_2025-08-19_15-48-03" src="https://github.com/user-attachments/assets/82e9137b-3eca-42f6-88c3-2ec7e1f240c0" />

## After
<img width="303" height="94" alt="chrome_2025-08-19_16-05-54" src="https://github.com/user-attachments/assets/9f8a6325-817d-4b71-8553-ff4994e7e39f" />

