### PR TITLE
Fix #233: Add missing "common.js" load for "/account/licenses"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -223,6 +223,7 @@
 			],
 			"js":
 			[
+				"scripts/common.js",
 				"scripts/store/account_licenses.js"
 			],
 			"css":


### PR DESCRIPTION
`scripts/store/account_licenses.js` uses `GetOption(...)` in `scripts/common.js` but doesn't reference it in its script embed section. While `common.js` is injected generally for all pages under `https://store.steampowered.com/*`, looks like it's not there by the time `GetOption(...)` is called. This settles the race condition. (Tested locally in Developer Mode on Microsoft Edge 139.0.3405.125)